### PR TITLE
Fix sources dropdown visibility on Chelsea Piers dark theme

### DIFF
--- a/components/ai-elements/sources.tsx
+++ b/components/ai-elements/sources.tsx
@@ -13,7 +13,7 @@ export type SourcesProps = ComponentProps<"div">;
 
 export const Sources = ({ className, ...props }: SourcesProps) => (
   <Collapsible
-    className={cn("not-prose mb-4 text-primary text-xs", className)}
+    className={cn("not-prose mb-4 text-blue-300 text-sm", className)}
     {...props}
   />
 );
@@ -29,13 +29,16 @@ export const SourcesTrigger = ({
   ...props
 }: SourcesTriggerProps) => (
   <CollapsibleTrigger
-    className={cn("flex items-center gap-2", className)}
+    className={cn(
+      "flex items-center gap-2 font-medium text-blue-300 hover:text-blue-200 transition-colors",
+      className
+    )}
     {...props}
   >
     {children ?? (
       <>
         <p className="font-medium">Used {count} sources</p>
-        <ChevronDownIcon className="h-4 w-4" />
+        <ChevronDownIcon className="h-5 w-5" />
       </>
     )}
   </CollapsibleTrigger>


### PR DESCRIPTION
## Summary
Fixes sources dropdown visibility issue on the new Chelsea Piers dark theme where the "Used 4 sources" button was invisible to users.

## Changes
- **Sources component**: 
  - `text-primary` → `text-blue-300` (better contrast on dark background)
  - `text-xs` → `text-sm` (improved readability)
- **SourcesTrigger component**:
  - Added `font-medium` for emphasis
  - Added `text-blue-300` for consistent color
  - Added `hover:text-blue-200` for interactive feedback
  - Added `transition-colors` for smooth hover effect
  - Increased ChevronDownIcon: `h-4 w-4` → `h-5 w-5`

## Testing
- ✅ TypeScript compilation passes (0 errors)
- ✅ Build passes successfully
- ✅ Pre-commit hooks validated
- Visual testing needed on Chelsea Piers theme Vercel preview

## Impact
- **Priority**: P0 - Critical UX
- **Files Modified**: `components/ai-elements/sources.tsx` (6 insertions, 3 deletions)
- **User Impact**: Users can now see and interact with source citations

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)